### PR TITLE
Extract the complaints table into separate component from DashboardPage

### DIFF
--- a/challenge/frontend/src/components/ComplaintTable.jsx
+++ b/challenge/frontend/src/components/ComplaintTable.jsx
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview ComplaintTable component for displaying complaint data in tabular format
+ * @module components/ComplaintTable
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Configuration for complaint table columns
+ * @typedef {Object} TableColumn
+ * @property {string} key - The key to access the data in complaint object
+ * @property {string} header - Display text for the column header
+ * @property {Function} [formatter] - Optional function to format the cell value
+ */
+
+/**
+ * Defines the structure and formatting of the complaints table
+ * @type {TableColumn[]}
+ */
+export const COMPLAINT_TABLE_COLUMNS = [
+  { key: 'complaint_type', header: 'Type' },
+  { key: 'descriptor', header: 'Description' },
+  { key: 'zip', header: 'Zipcode' },
+  { key: 'borough', header: 'Borough' },
+  { key: 'city', header: 'City' },
+  { key: 'council_dist', header: 'Council District' },
+  { key: 'community_board', header: 'Community Board' },
+  { key: 'opendate', header: 'Open Date' },
+  { key: 'closedate', header: 'Close Date', formatter: (value) => value || 'Open' }
+];
+
+/**
+ * ComplaintTable component renders a table of complaint data
+ * 
+ * @component
+ * @param {Object} props - Component props
+ * @param {Array} props.complaints - Array of complaint objects to display
+ * @returns {JSX.Element} Table containing complaint data
+ * 
+ * @example
+ * <ComplaintTable complaints={complaintData} />
+ */
+const ComplaintTable = ({ complaints }) => (
+  <table className="complaint-table">
+    <thead>
+      <tr>
+        {COMPLAINT_TABLE_COLUMNS.map(column => (
+          <th key={column.key}>{column.header}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {complaints.map((complaint) => (
+        <tr key={complaint.unique_key}>
+          {COMPLAINT_TABLE_COLUMNS.map(column => (
+            <td key={column.key}>
+              {column.formatter 
+                ? column.formatter(complaint[column.key])
+                : complaint[column.key]}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+ComplaintTable.propTypes = {
+  complaints: PropTypes.arrayOf(PropTypes.shape({
+    unique_key: PropTypes.string.isRequired,
+    complaint_type: PropTypes.string,
+    descriptor: PropTypes.string,
+    zip: PropTypes.string,
+    borough: PropTypes.string,
+    city: PropTypes.string,
+    council_dist: PropTypes.string,
+    community_board: PropTypes.string,
+    opendate: PropTypes.string,
+    closedate: PropTypes.string
+  })).isRequired
+};
+
+export default ComplaintTable;

--- a/challenge/frontend/src/components/ComplaintTable.jsx
+++ b/challenge/frontend/src/components/ComplaintTable.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 
 /**
  * Ordered map that defines the structure and formatting of the complaints table
+ * Array index reflects the order of the table columns shown to the member
  * @type {TableColumn[]}
  */
 export const COMPLAINT_TABLE_COLUMNS = [

--- a/challenge/frontend/src/components/ComplaintTable.jsx
+++ b/challenge/frontend/src/components/ComplaintTable.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * Configuration for complaint table columns
  * @typedef {Object} TableColumn
  * @property {string} key - The key to access the data in complaint object
  * @property {string} header - Display text for the column header
@@ -15,7 +14,7 @@ import PropTypes from 'prop-types';
  */
 
 /**
- * Defines the structure and formatting of the complaints table
+ * Ordered map that defines the structure and formatting of the complaints table
  * @type {TableColumn[]}
  */
 export const COMPLAINT_TABLE_COLUMNS = [

--- a/challenge/frontend/src/components/ComplaintTable.test.jsx
+++ b/challenge/frontend/src/components/ComplaintTable.test.jsx
@@ -35,7 +35,7 @@ describe('ComplaintTable', () => {
         render(<ComplaintTable complaints={mockComplaints} />);
         
         COMPLAINT_TABLE_COLUMNS.forEach(column => {
-        expect(screen.getByText(column.header)).toBeInTheDocument();
+            expect(screen.getByText(column.header)).toBeInTheDocument();
         });
     });
 
@@ -58,7 +58,7 @@ describe('ComplaintTable', () => {
         render(<ComplaintTable complaints={[]} />);
         
         COMPLAINT_TABLE_COLUMNS.forEach(column => {
-        expect(screen.getByText(column.header)).toBeInTheDocument();
+            expect(screen.getByText(column.header)).toBeInTheDocument();
         });
     });
 });

--- a/challenge/frontend/src/components/ComplaintTable.test.jsx
+++ b/challenge/frontend/src/components/ComplaintTable.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ComplaintTable, { COMPLAINT_TABLE_COLUMNS } from './ComplaintTable';
+
+describe('ComplaintTable', () => {
+    /* Mocks */
+    const mockComplaints = [
+        {
+            unique_key: '1',
+            complaint_type: 'Aging',
+            descriptor: 'Senior Centers',
+            borough: 'Brooklyn',
+            city: 'New York',
+            zip: '11201',
+            council_dist: 'NYCC01',
+            community_board: '301',
+            opendate: '2024-01-01',
+            closedate: '2024-01-02'
+        },
+        {
+            unique_key: '2',
+            complaint_type: 'Health',
+            descriptor: 'Rats/Rodents',
+            borough: 'Manhattan',
+            city: 'New York',
+            zip: '10001',
+            council_dist: 'NYCC02',
+            community_board: '102',
+            opendate: '2024-01-01',
+            closedate: null
+        }
+    ];
+
+    it('renders all column headers', () => {
+        render(<ComplaintTable complaints={mockComplaints} />);
+        
+        COMPLAINT_TABLE_COLUMNS.forEach(column => {
+        expect(screen.getByText(column.header)).toBeInTheDocument();
+        });
+    });
+
+    it('renders complaint data correctly', () => {
+        render(<ComplaintTable complaints={mockComplaints} />);
+        
+        expect(screen.getByText('Aging')).toBeInTheDocument();
+        expect(screen.getByText('Senior Centers')).toBeInTheDocument();
+        expect(screen.getByText('Brooklyn')).toBeInTheDocument();
+    });
+
+    it('formats closedate correctly', () => {
+        render(<ComplaintTable complaints={mockComplaints} />);
+        
+        expect(screen.getByText('2024-01-02')).toBeInTheDocument();
+        expect(screen.getByText('Open')).toBeInTheDocument();
+    });
+
+    it('handles empty complaints array', () => {
+        render(<ComplaintTable complaints={[]} />);
+        
+        COMPLAINT_TABLE_COLUMNS.forEach(column => {
+        expect(screen.getByText(column.header)).toBeInTheDocument();
+        });
+    });
+});

--- a/challenge/frontend/src/components/DashboardPage.jsx
+++ b/challenge/frontend/src/components/DashboardPage.jsx
@@ -4,6 +4,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import ComplaintTable from './ComplaintTable';
 import './../styles/DashboardPage.css';
 
 /**
@@ -21,30 +22,6 @@ const DashboardPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const history = useHistory();
-
-  /**
-   * Configuration for complaint table columns
-   * @typedef {Object} TableColumn
-   * @property {string} key - The key to access the data in complaint object
-   * @property {string} header - Display text for the column header
-   * @property {Function} [formatter] - Optional function to format the cell value
-   */
-
-  /**
-   * Defines the structure and formatting of the complaints table
-   * @type {TableColumn[]}
-   */
-  const DASHBOARD_TABLE_COLUMNS = [
-    { key: 'complaint_type', header: 'Type' },
-    { key: 'descriptor', header: 'Description' },
-    { key: 'zip', header: 'Zipcode' },
-    { key: 'borough', header: 'Borough' },
-    { key: 'city', header: 'City' },
-    { key: 'council_dist', header: 'Council District' },
-    { key: 'community_board', header: 'Community Board' },
-    { key: 'opendate', header: 'Open Date' },
-    { key: 'closedate', header: 'Close Date', formatter: (value) => value || 'Open' }
-  ];
 
   useEffect(() => {
     /**
@@ -112,28 +89,7 @@ const DashboardPage = () => {
           </div>
           
           <div className="complaint-table-wrapper">
-          <table className="complaint-table">
-            <thead>
-                <tr>
-                    {DASHBOARD_TABLE_COLUMNS.map(column => (
-                        <th key={column.key}>{column.header}</th>
-                    ))}
-                </tr>
-            </thead>
-            <tbody>
-                {complaints.map((complaint) => (
-                <tr key={complaint.unique_key}>
-                    {DASHBOARD_TABLE_COLUMNS.map(column => (
-                    <td key={column.key}>
-                        {column.formatter 
-                        ? column.formatter(complaint[column.key])
-                        : complaint[column.key]}
-                    </td>
-                    ))}
-                </tr>
-                ))}
-            </tbody>
-            </table>
+            <ComplaintTable complaints={complaints} />
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary

This PR extracts the complaints table into separate component from DashboardPage - no UX impact, only done to make DashboardPage easier to read.

## Screenshot
![image](https://github.com/user-attachments/assets/94115dc8-6f68-449d-90f5-5f60bfc7365f)


## Tests
`npm run test`
![image](https://github.com/user-attachments/assets/4f3ac443-7882-4825-b9c6-4cdfd21d8e11)

`./test.bat`