### PR TITLE
Use new complaint endpoint and viewset to fulfill project req's

### DIFF
--- a/challenge/frontend/src/components/DashboardPage.test.jsx
+++ b/challenge/frontend/src/components/DashboardPage.test.jsx
@@ -290,6 +290,22 @@ describe('Constituent View Tests', () => {
     expect(screen.getByText('All District Complaints')).toBeInTheDocument();
     const toggleButton = screen.getByText("Show My Constituents' Complaints");
     expect(toggleButton).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/complaints/allComplaints/',
+      expect.any(Object)
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/complaints/openCases/',
+      expect.any(Object)
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/complaints/closedCases/',
+      expect.any(Object)
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/complaints/topComplaints/',
+      expect.any(Object)
+    );
 
     toggleButton.click();
 
@@ -298,10 +314,6 @@ describe('Constituent View Tests', () => {
       expect(screen.getByText('Show All District Complaints')).toBeInTheDocument();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:8000/api/complaints/allComplaints/?constituent=true',
-      expect.any(Object)
-    );
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:8000/api/complaints/openCases/?constituent=true',
       expect.any(Object)
@@ -312,6 +324,10 @@ describe('Constituent View Tests', () => {
     );
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:8000/api/complaints/topComplaints/?constituent=true',
+      expect.any(Object)
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/complaints/constituentComplaints/',
       expect.any(Object)
     );
   });


### PR DESCRIPTION
## Summary
This PR uses the new complaint endpoint and viewset to fulfill project reqs (rather than using a param for `/allComplaints` specifically).

## Details
**Note:** This also triggers new api calls that adjust the statistic cards displayed, but it's possible to not do that. This can be changed depending on product requirements, but going with the updated version for now with the constituent param in case the council member wants to see the updated statistics for their own district only.

## Screenshots
![image](https://github.com/user-attachments/assets/9dc9b241-44bb-48bb-b8e5-9f39d2932a6f)
![image](https://github.com/user-attachments/assets/f255d1d6-9d59-4a2a-ae16-e7076f4a64cb)


## Tests
`./test.bat && npm run test`