### PR TITLE
Move string format for district num into util

### DIFF
--- a/challenge/backend/tests/test_string_utils.py
+++ b/challenge/backend/tests/test_string_utils.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from complaint_app.utils.string_utils import format_district_number
+
+class DistrictNumberFormattingTests(TestCase):
+    def test_single_digit_district(self):
+        """Test that single digit districts are zero-padded"""
+        self.assertEqual(format_district_number(1), "NYCC01")
+        self.assertEqual(format_district_number("1"), "NYCC01")
+        self.assertEqual(format_district_number(9), "NYCC09")
+
+    def test_double_digit_district(self):
+        """Test that double digit districts are formatted correctly"""
+        self.assertEqual(format_district_number(10), "NYCC10")
+        self.assertEqual(format_district_number("51"), "NYCC51")

--- a/challenge/complaint_app/utils/string_utils.py
+++ b/challenge/complaint_app/utils/string_utils.py
@@ -1,0 +1,17 @@
+def format_district_number(district_number):
+    """
+    Formats a district number into the standardized NYCC format.
+    Adds extra padding as needed for single-digit numbers.
+    Example: 1 -> "NYCC01", 12 -> "NYCC12"
+
+    @param district_number - The district number to format
+
+    @return str - The formatted district string in NYCC format
+
+    @except ValueError - If district_number is not a valid number between 1 and 51
+    """
+    try:
+        number = int(district_number)
+        return f"NYCC{number:02d}"
+    except:
+        raise ValueError("Invalid district number")

--- a/challenge/complaint_app/utils/string_utils.py
+++ b/challenge/complaint_app/utils/string_utils.py
@@ -7,11 +7,6 @@ def format_district_number(district_number):
     @param district_number - The district number to format
 
     @return str - The formatted district string in NYCC format
-
-    @except ValueError - If district_number is not a valid number between 1 and 51
     """
-    try:
-        number = int(district_number)
-        return f"NYCC{number:02d}"
-    except:
-        raise ValueError("Invalid district number")
+    number = int(district_number)
+    return f"NYCC{number:02d}"

--- a/challenge/complaint_app/views.py
+++ b/challenge/complaint_app/views.py
@@ -4,6 +4,7 @@ from .serializers import UserSerializer, UserProfileSerializer, ComplaintSeriali
 from rest_framework.response import Response
 from rest_framework import status
 from django.db.models import Count
+from .utils.string_utils import format_district_number
 
 # Create your views here.
 
@@ -15,7 +16,7 @@ class ComplaintViewSet(viewsets.ModelViewSet):
     try:
         user_profile = UserProfile.objects.get(user=request.user)
         district_number = user_profile.district
-        padded_district = f"NYCC{int(district_number):02d}"
+        padded_district = format_district_number(district_number)
 
         # BONUS CHALLENGE EXTRA: Check if we want constituent data
         is_constituent = request.query_params.get('constituent', '').lower() == 'true'
@@ -48,7 +49,7 @@ class OpenCasesViewSet(viewsets.ModelViewSet):
     try:
       user_profile = UserProfile.objects.get(user=request.user)
       district_number = user_profile.district
-      padded_district = f"NYCC{int(district_number):02d}"
+      padded_district = format_district_number(district_number)
 
       # BONUS CHALLENGE EXTRA: Check if we want constituent data
       is_constituent = request.query_params.get('constituent', '').lower() == 'true'
@@ -85,7 +86,7 @@ class ClosedCasesViewSet(viewsets.ModelViewSet):
     try:
       user_profile = UserProfile.objects.get(user=request.user)
       district_number = user_profile.district
-      padded_district = f"NYCC{int(district_number):02d}"
+      padded_district = format_district_number(district_number)
 
       # BONUS CHALLENGE EXTRA: Check if we want constituent data
       is_constituent = request.query_params.get('constituent', '').lower() == 'true'
@@ -120,7 +121,7 @@ class TopComplaintTypeViewSet(viewsets.ModelViewSet):
     try:
       user_profile = UserProfile.objects.get(user=request.user)
       district_number = user_profile.district
-      padded_district = f"NYCC{int(district_number):02d}"
+      padded_district = format_district_number(district_number)
 
       # BONUS CHALLENGE EXTRA: Check if we want constituent data
       is_constituent = request.query_params.get('constituent', '').lower() == 'true'


### PR DESCRIPTION
## Summary
Extract `f"NYCC{int(district_number):02d}"` which was reused across viewsets into a documented utils file

## Screenshots
![image](https://github.com/user-attachments/assets/72eefe5f-b1e1-4a09-9aa1-9b45fd41827d)

## Tests
`npm run test`, `./test.bat`